### PR TITLE
feat: トップページに使い方ページを追加し、各ページに使い方ページへのリンクボタンを追加

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,13 +12,17 @@ import {
   HomeRoute,
   HealthHazardsSubRoutes
 } from '@/router/routes'
-import { AppBarTitle, AppBarColor } from '@/router/data'
+import { AppBarTitle, AppBarColor, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import { shallowRef } from 'vue'
 
 const baseURL = import.meta.env.BASE_URL
 
 const selectedItem = shallowRef('')
 const drawer = shallowRef<boolean>(false)
+
+// メモ:
+// v-app-bar-title を使うと画面サイズによってはタイトルが文字切れしてしまうため、独自の実装で
+// 文字切れしないようにしている。
 </script>
 
 <template>
@@ -27,7 +31,15 @@ const drawer = shallowRef<boolean>(false)
       <template v-slot:prepend>
         <v-app-bar-nav-icon variant="text" @click.stop="drawer = !drawer"></v-app-bar-nav-icon>
         <v-toolbar-title class="d-none d-sm-flex">{{ AppBarTitle }}</v-toolbar-title>
-        <v-toolbar-title class="d-flex d-sm-none small-app-title">{{ AppBarTitle }}</v-toolbar-title>
+        <v-toolbar-title class="d-flex d-sm-none small-app-title">
+          <span v-for="(item, index) in AppBarTitle.split('-')" :key="index">{{ item }}<br></span>
+        </v-toolbar-title>
+        <v-hover v-if="AppBarUseHelpPage">
+          <template v-slot:default="{ isHovering, props }">
+            <v-btn prepend-icon="mdi-book-open-page-variant-outline" :href="`${baseURL}#${AppBarHelpPageLink}`"
+              class="ml-4" variant=elevated v-bind="props" :color="isHovering ? 'grey-lighten-2' : undefined" :elevation="isHovering ? 10 : 2" text="使い方"></v-btn>
+          </template>
+        </v-hover>
       </template>
     </v-app-bar>
 
@@ -291,7 +303,7 @@ const drawer = shallowRef<boolean>(false)
 }
 
 .small-app-title {
-  font-size: 0.85rem;
+  font-size: 1rem;
 }
 
 .v-list-group {

--- a/src/router/data.ts
+++ b/src/router/data.ts
@@ -2,6 +2,8 @@ import { shallowRef } from 'vue'
 
 export const AppBarTitle = shallowRef('副反応ダッシュボード')
 export const AppBarColor = shallowRef('white')
+export const AppBarUseHelpPage = shallowRef(false)
+export const AppBarHelpPageLink = shallowRef('')
 
 // production
 const DatasetsURL = import.meta.env.VITE_DATASETS_URL

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { AppBarTitle, AppBarColor } from '@/router/data'
+import { AppBarTitle, AppBarColor, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import router from '@/router/index'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = 'blue-grey-lighten-4'
+AppBarUseHelpPage.value = false
+AppBarHelpPageLink.value = ''
 </script>
 
 <template>

--- a/src/views/CertifiedHealthHazardsHomeView.vue
+++ b/src/views/CertifiedHealthHazardsHomeView.vue
@@ -146,7 +146,7 @@
 <script setup lang="ts">
 import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
-import { AppBarTitle, AppBarColor, CertifiedSummaryURL, CertifiedSummaryWithOtherVaccinesURL, CertifiedTrendsURL } from '@/router/data'
+import { AppBarTitle, AppBarColor, CertifiedSummaryURL, CertifiedSummaryWithOtherVaccinesURL, CertifiedTrendsURL, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import router from '@/router/index'
 import type { ICertifiedSummary, ICertifiedSummaryWithOtherVaccines } from '@/types/CertifiedSummary'
 import type { ICertifiedTrends } from '@/types/CertifiedTrends'
@@ -154,6 +154,8 @@ import { CreateBarChartOption } from '@/tools/ChartOptions'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = 'green'
+AppBarUseHelpPage.value = true
+AppBarHelpPageLink.value = 'how-to-use-summary-page'
 
 const isPersentView = shallowRef(true)
 

--- a/src/views/CertifiedHealthHazardsView.vue
+++ b/src/views/CertifiedHealthHazardsView.vue
@@ -158,7 +158,7 @@
 import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
 import router from '@/router/index'
-import { AppBarTitle, AppBarColor, CertifiedHealthHazardDataURL, CertifiedMetadataURL } from '@/router/data'
+import { AppBarTitle, AppBarColor, CertifiedHealthHazardDataURL, CertifiedMetadataURL, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import type { ICertifiedHealthHazardIssue } from '@/types/CertifiedHealthHazard'
 import type { IQueryParam } from '@/types/QueryParam'
 import { ClearFilterValues, CreateUrlWithQueryParams, IsConditionChanged, ParseQueryParams } from '@/types/QueryParam'
@@ -177,6 +177,8 @@ import SearchRelatedToolBar from '@/components/SearchRelatedToolBar.vue'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = 'green'
+AppBarUseHelpPage.value = true
+AppBarHelpPageLink.value = 'how-to-search'
 
 const loading = shallowRef(true)
 const dataTableItems = shallowRef<ICertifiedHealthHazardIssue[]>()

--- a/src/views/CertifiedSymptomsView.vue
+++ b/src/views/CertifiedSymptomsView.vue
@@ -66,7 +66,7 @@
 import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
 import router from '@/router/index'
-import { AppBarTitle, AppBarColor, CertifiedSymptomsDataURL, CertifiedSymptomsMetadataURL } from '@/router/data'
+import { AppBarTitle, AppBarColor, CertifiedSymptomsDataURL, CertifiedSymptomsMetadataURL, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import type { ICertifiedSymptom } from '@/types/CertifiedSymptom'
 import type { IQueryParam } from '@/types/QueryParam'
 import { ClearFilterValues, CreateUrlWithQueryParams, IsConditionChanged, ParseQueryParams } from '@/types/QueryParam'
@@ -80,6 +80,8 @@ import NumberFilter from '@/components/NumberFilter.vue'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = 'green'
+AppBarUseHelpPage.value = true
+AppBarHelpPageLink.value = 'how-to-search'
 
 const loading = shallowRef(true)
 const dataTableItems = shallowRef<ICertifiedSymptom[]>()

--- a/src/views/DeathView.vue
+++ b/src/views/DeathView.vue
@@ -187,7 +187,6 @@
 </template>
 
 <script setup lang="ts">
-import type { ShallowRef } from 'vue'
 import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
 import type { IReportedDeathIssue } from '@/types/ReportedDeath'
@@ -196,7 +195,7 @@ import { ClearFilterValues, CreateUrlWithQueryParams, IsConditionChanged, ParseQ
 import { CreateCsvContentRaw, DownloadCsvFile } from '@/types/FilteredDataAsCsv'
 import type { IDeathSummaryFromReportsRoot } from '@/types/DeathSummaryFromReports'
 import type { IDeathMetadata } from '@/types/DeathMetadata'
-import { AppBarTitle, AppBarColor, DeathReportsURL, DeathSummaryFromReportsURL, DeathMetadataURL } from '@/router/data'
+import { AppBarTitle, AppBarColor, DeathReportsURL, DeathSummaryFromReportsURL, DeathMetadataURL, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import router from '@/router/index'
 import { SearchTrigger, SearchTriggerFunc } from '@/tools/SearchTriggerFunc'
 import { NumberFilterFunc, DateFilterFunc, StringFilterFunc, DateArrayFilterFunc, StringArrayFilterFunc } from '@/tools/FilterFunc'
@@ -214,6 +213,8 @@ import DateFilter from '@/components/DateFilter.vue'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = '#2962ff'
+AppBarUseHelpPage.value = true
+AppBarHelpPageLink.value = 'how-to-search'
 
 const loading = shallowRef(true)
 const dataTableItems = shallowRef<IReportedDeathIssue[]>()

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -134,10 +134,29 @@
       </v-expand-transition>
     </v-card>
   </v-container>
+
+  <v-container>
+    <v-card color="blue-grey-lighten-1" variant="elevated">
+      <v-card-title>使い方の説明</v-card-title>
+      <v-card-text class="card-text">
+        検索ページや集計結果ページの使い方を解説した記事です。
+      </v-card-text>
+
+      <v-item-group selected-class="bg-primary">
+        <v-container>
+          <v-row>
+            <v-col cols="12" lg="3" md="4" sm="6" v-for="(r, i) in HowToUseSearchPageRoutes" :key="i">
+              <v-btn :prepend-icon="r.icon" size="x-large" :href="`${baseURL}#${r.path}`" min-width="17rem">{{ r.menu_name }}</v-btn>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-item-group>
+    </v-card>
+  </v-container>
 </template>
 
 <script setup lang="ts">
-import { AppBarTitle, AppBarColor } from '@/router/data'
+import { AppBarTitle, AppBarColor, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import {
   HealthHazardsHomeRoute,
   HealthHazardsSubRoutes,
@@ -145,13 +164,16 @@ import {
   SuspectedIssuesSubRoutes,
   MedialInstitutionHomeRoute,
   MedialInstitutionRoutes,
-  MedialInstitutionReferenceRoute
+  MedialInstitutionReferenceRoute,
+  HowToUseSearchPageRoutes
 } from '@/router/routes'
 import { shallowRef } from 'vue'
 import router from '@/router/index'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = '#E57373'
+AppBarUseHelpPage.value = false
+AppBarHelpPageLink.value = ''
 
 const baseURL = import.meta.env.BASE_URL
 const expandSuspectedIssues = shallowRef(false)

--- a/src/views/HowToSearch.vue
+++ b/src/views/HowToSearch.vue
@@ -120,12 +120,14 @@
 </template>
 
 <script setup lang="ts">
-import { AppBarTitle, AppBarColor } from '@/router/data'
+import { AppBarTitle, AppBarColor, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import router from '@/router/index'
 import CopyLinkSnackBar from '@/components/CopyLinkSnackBar.vue'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = 'blue-grey-lighten-4'
+AppBarUseHelpPage.value = false
+AppBarHelpPageLink.value = ''
 
 const sectionOpenSearchWindow = { title: '検索画面を開く', id: 'open-search-window', position: 'top' }
 const sectionFilterByClaim = { title: '請求内容で検索する', id: 'search-by-claim', position: 'top' }

--- a/src/views/HowToUseSummary.vue
+++ b/src/views/HowToUseSummary.vue
@@ -45,12 +45,14 @@
 </template>
 
 <script setup lang="ts">
-import { AppBarTitle, AppBarColor } from '@/router/data'
+import { AppBarTitle, AppBarColor, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import router from '@/router/index'
 import CopyLinkSnackBar from '@/components/CopyLinkSnackBar.vue'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = 'blue-grey-lighten-4'
+AppBarUseHelpPage.value = false
+AppBarHelpPageLink.value = ''
 
 const sectionSelectPercentOrCount = { title: '割合表示と件数表示を切り替える', id: 'select-percent-or-count', position: 'top' }
 const sectionSaveGraph = { title: 'グラフを保存する', id: 'save-graph', position: 'middle' }

--- a/src/views/MedicalInstitutionReferenceView.vue
+++ b/src/views/MedicalInstitutionReferenceView.vue
@@ -83,7 +83,7 @@
 <script setup lang="ts">
 import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
-import { AppBarTitle, AppBarColor, MedicalInstitutionSummaryURL } from '@/router/data'
+import { AppBarTitle, AppBarColor, MedicalInstitutionSummaryURL, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import router from '@/router/index'
 import { type IMedicalInstitutionSummary } from '@/types/MedicalInstitutionReports'
 import type { ILotNumberItem } from '@/types/LotNumberInfomation'
@@ -91,6 +91,8 @@ import { CreateBarChartOption } from '@/tools/ChartOptions'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = 'blue-accent-1'
+AppBarUseHelpPage.value = true
+AppBarHelpPageLink.value = 'how-to-use-summary-page'
 
 const medicalInstitutionSummary = shallowRef<IMedicalInstitutionSummary>()
 onMounted(() => {

--- a/src/views/MedicalInstitutionSummaryView.vue
+++ b/src/views/MedicalInstitutionSummaryView.vue
@@ -45,13 +45,15 @@
 <script setup lang="ts">
 import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
-import { AppBarTitle, AppBarColor, MedicalInstitutionSummaryURL } from '@/router/data'
+import { AppBarTitle, AppBarColor, MedicalInstitutionSummaryURL, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import router from '@/router/index'
 import { type IMedicalInstitutionSummary } from '@/types/MedicalInstitutionReports'
 import { CreatePieChartOption } from '@/tools/ChartOptions'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = '#2962ff'
+AppBarUseHelpPage.value = true
+AppBarHelpPageLink.value = 'how-to-use-summary-page'
 
 const medicalInstitutionSummary = shallowRef<IMedicalInstitutionSummary>()
 onMounted(() => {

--- a/src/views/MedicalInstitutionView.vue
+++ b/src/views/MedicalInstitutionView.vue
@@ -199,7 +199,7 @@
 import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
 import router from '@/router/index'
-import { AppBarTitle, AppBarColor, MedicalInstitutionReportsURL, MedicalInstitutionSummaryURL, MedicalInstitutionMetadataURL } from '@/router/data'
+import { AppBarTitle, AppBarColor, MedicalInstitutionReportsURL, MedicalInstitutionSummaryURL, MedicalInstitutionMetadataURL, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import { DateArrayFilterFunc, NumberFilterFunc, StringArrayFilterFunc, StringFilterFunc } from '@/tools/FilterFunc'
 import { SearchTrigger, SearchTriggerFunc } from '@/tools/SearchTriggerFunc'
 import type { IQueryParam } from '@/types/QueryParam'
@@ -220,6 +220,8 @@ import ManufacturerHelpDialog from '@/components/ManufacturerHelpDialog.vue'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = '#2962ff'
+AppBarUseHelpPage.value = true
+AppBarHelpPageLink.value = 'how-to-search'
 
 const loading = shallowRef(true)
 const dataTableItems = shallowRef<IMedicalInstitutionReport[]>()

--- a/src/views/MyocarditisView.vue
+++ b/src/views/MyocarditisView.vue
@@ -179,7 +179,7 @@ import { ClearFilterValues, CreateUrlWithQueryParams, IsConditionChanged, ParseQ
 import { CreateCsvContentRaw, DownloadCsvFile } from '@/types/FilteredDataAsCsv'
 import type { ICarditisMetadata } from '@/types/CarditisMetadata'
 import type { ICarditisSummaryRoot } from '@/types/CarditisSummary'
-import { AppBarTitle, AppBarColor, CarditisReportsURL, CarditisSummaryURL, CarditisMetadataURL } from '@/router/data'
+import { AppBarTitle, AppBarColor, CarditisReportsURL, CarditisSummaryURL, CarditisMetadataURL, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import router from '@/router/index'
 import { DateArrayFilterFunc, DateFilterFunc, NumberFilterFunc, StringArrayFilterFunc, StringFilterFunc } from '@/tools/FilterFunc'
 import { SearchTrigger, SearchTriggerFunc } from '@/tools/SearchTriggerFunc'
@@ -195,6 +195,8 @@ import EvaluationResultHelpDialog from '@/components/EvaluationResultHelpDialog.
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = '#2962ff'
+AppBarUseHelpPage.value = true
+AppBarHelpPageLink.value = 'how-to-search'
 
 const loading = shallowRef(true)
 const dataTableItems = shallowRef<IReportedMyocarditisIssue[]>()

--- a/src/views/SuspectedIssuesReferenceView.vue
+++ b/src/views/SuspectedIssuesReferenceView.vue
@@ -123,7 +123,7 @@
 <script setup lang="ts">
 import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
-import { AppBarTitle, AppBarColor, CarditisSummaryFromReportsURL, DeathSummaryFromReportsURL } from '@/router/data'
+import { AppBarTitle, AppBarColor, CarditisSummaryFromReportsURL, DeathSummaryFromReportsURL, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import router from '@/router/index'
 import type { ILotNumberItem } from '@/types/LotNumberInfomation'
 import { CreateBarChartOption } from '@/tools/ChartOptions'
@@ -132,6 +132,8 @@ import type { IDeathSummaryFromReportsRoot } from '@/types/DeathSummaryFromRepor
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = 'blue-accent-1'
+AppBarUseHelpPage.value = true
+AppBarHelpPageLink.value = 'how-to-use-summary-page'
 
 const carditisSummary = shallowRef<ICarditisSummaryFromReportsRoot>()
 const deathSummary = shallowRef<IDeathSummaryFromReportsRoot>()

--- a/src/views/SuspectedIssuesView.vue
+++ b/src/views/SuspectedIssuesView.vue
@@ -246,7 +246,7 @@
 <script setup lang="ts">
 import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
-import { AppBarTitle, AppBarColor, CarditisSummaryURL, DeathSummaryURL, DeathSummaryFromReportsURL } from '@/router/data'
+import { AppBarTitle, AppBarColor, CarditisSummaryURL, DeathSummaryURL, DeathSummaryFromReportsURL, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import router from '@/router/index'
 import type { ICarditisSummaryRoot } from '@/types/CarditisSummary'
 import type { IDeathSummaryRoot } from '@/types/DeathSummary'
@@ -255,6 +255,8 @@ import EvaluationResultHelpDialog from '@/components/EvaluationResultHelpDialog.
 
 AppBarTitle.value = String(router.currentRoute.value.name)
 AppBarColor.value = '#2962ff'
+AppBarUseHelpPage.value = true
+AppBarHelpPageLink.value = 'how-to-use-summary-page'
 
 const carditisSummaryData = shallowRef<ICarditisSummaryRoot>()
 const deathSummaryData = shallowRef<IDeathSummaryRoot>()


### PR DESCRIPTION
検証用：

トップページの末尾に、使い方ページへのリンクを追加。
![image](https://github.com/user-attachments/assets/d0bbfffd-010f-478b-9ef6-599e7d155736)

ページタイトルの右横に、使い方ページを開くボタンを追加。
![image](https://github.com/user-attachments/assets/1acb3dd4-6731-47b8-a053-773daa33ed08)
