### PR TITLE
feat: 製造販売業者からの報告サマリページを改善

### DIFF
--- a/src/components/CarditisPerAgeGraph.vue
+++ b/src/components/CarditisPerAgeGraph.vue
@@ -48,19 +48,19 @@ shortChartOption.value = sChartOp
 </script>
 
 <script lang="ts">
-const downloadFileName = 'death-per-age-graph'
+const downloadFileName = 'carditis-per-age-graph'
 
 const numberFormatter = (value: any) => { return value.toLocaleString() }
 const issueFormatter = (value: any) => { return value.toLocaleString() + ' 人' }
 const createBaseChartOption = (): any =>{
   return {
     title: {
-      text: '亡くなられた方々の人数（年代別）',
+      text: '心筋炎/心膜炎の方々の人数（年代別）',
 	    floating: true
     },
     chart: {
       type: 'bar',
-      toolbar:{
+	    toolbar:{
         export: {
           csv: {
             filename: downloadFileName,
@@ -79,7 +79,7 @@ const createBaseChartOption = (): any =>{
       title: {
         text: '人数'
       },
-	    labels: {
+      labels: {
         formatter: numberFormatter
       },
     },
@@ -99,10 +99,10 @@ const createBaseChartOption = (): any =>{
       y: {
         formatter: issueFormatter,
         title: {
-          formatter: (): string => {
-            return `人数: `
-          }
-        }
+			    formatter: (): string => {
+				    return `人数: `
+			    }
+		    }
       },
     },
     plotOptions: {

--- a/src/components/CountAndRateGraph.vue
+++ b/src/components/CountAndRateGraph.vue
@@ -175,7 +175,7 @@ const CreateCountAndRateChartOption = (info: IJudgedDataGraphInfo, labels: strin
       offsetY: 20
     },
     tooltip: {
-    y: {
+      y: {
         formatter: function(value: any, { series, seriesIndex, dataPointIndex, w } :any) {
           if(w.config.series[seriesIndex].name == info.RateSeriesName){
             return (value as number).toFixed(1) + ' %'

--- a/src/components/HorizontalBarGraph.vue
+++ b/src/components/HorizontalBarGraph.vue
@@ -21,12 +21,23 @@ const props = defineProps<{
 }>()
 
 const mediumChartOption = shallowRef<any>()
-mediumChartOption.value = createBaseChartOption(props.graphTitle, props.xAxisTitle, props.downloadFileName)
+const mChartOp = createBaseChartOption(props.graphTitle, props.xAxisTitle, props.downloadFileName)
+mChartOp.dataLabels.style = {
+	fontSize: '1rem',
+	colors: ['#818181'],
+}
+mChartOp.dataLabels.background = {
+	enabled: true,
+	foreColor: '#fff',
+}
+mChartOp.dataLabels.offsetX = 35
+mChartOp.dataLabels.offsetY = 6
+mediumChartOption.value = mChartOp
 
 const shortChartOption = shallowRef<any>()
 const sChartOp = createBaseChartOption(props.graphTitle, props.xAxisTitle, props.downloadFileName)
 sChartOp.dataLabels.style = {
-	fontSize: '0.7rem',
+	fontSize: '0.9rem',
 	colors: ['#818181'],
 }
 sChartOp.dataLabels.background = {
@@ -51,18 +62,18 @@ const createBaseChartOption = (graphTitle: string[], xAxisTitle: string, downloa
     },
     chart: {
       type: 'bar',
-	  toolbar:{
-		export: {
-			csv: {
-				filename: downloadFileName,
-			},
-			svg: {
-				filename: downloadFileName,
-			},
-			png: {
-				filename: downloadFileName,
-			}
-		},
+      toolbar:{
+        export: {
+          csv: {
+            filename: downloadFileName,
+          },
+          svg: {
+            filename: downloadFileName,
+          },
+          png: {
+            filename: downloadFileName,
+          }
+        },
       }
     },
     xaxis: {
@@ -70,7 +81,7 @@ const createBaseChartOption = (graphTitle: string[], xAxisTitle: string, downloa
         text: xAxisTitle
       },
 	  labels: {
-		formatter: numberFormatter
+		  formatter: numberFormatter
 	  },
     },
     yaxis: {

--- a/src/components/JudgedTrendsGraph.vue
+++ b/src/components/JudgedTrendsGraph.vue
@@ -69,12 +69,23 @@ const createBaseChartOption = (title: string): any =>{
 }
 
 const mediumChartOption = shallowRef<any>()
-mediumChartOption.value = createBaseChartOption(props.title)
+const mChartOp = createBaseChartOption(props.title)
+mChartOp.dataLabels.style = {
+	fontSize: '1rem',
+	colors: ['#818181'],
+}
+mChartOp.dataLabels.background = {
+	enabled: true,
+	foreColor: '#fff',
+}
+mChartOp.dataLabels.offsetX = 35
+mChartOp.dataLabels.offsetY = 6
+mediumChartOption.value = mChartOp
 
 const shortChartOption = shallowRef<any>()
 const sChartOp = createBaseChartOption(props.title)
 sChartOp.dataLabels.style = {
-	fontSize: '0.7rem',
+	fontSize: '0.9rem',
 	colors: ['#818181'],
 }
 sChartOp.dataLabels.background = {

--- a/src/components/OtherVaccinesGraph.vue
+++ b/src/components/OtherVaccinesGraph.vue
@@ -58,7 +58,7 @@ const medicalChartOption = CreateEachBillingDetailsChartOption([`${headerNames[0
 const disabilityOfChildrenChartOption = CreateEachBillingDetailsChartOption([`${headerNames[1]} の認定件数まとめ`], '#54E496', categories, false)
 const disabilityChartOption = CreateEachBillingDetailsChartOption([`${headerNames[2]} の認定件数まとめ`], '#F6AD21', categories, false)
 const header4Array = headerNames[3].split('・')
-const deathChartOption = CreateEachBillingDetailsChartOption([`${header4Array.slice(0,2)}`,`${header4Array.slice(2,4)} の認定件数まとめ`], '#F23B61', categories, false)
+const deathChartOption = CreateEachBillingDetailsChartOption([`${header4Array.slice(0,2).join('、')}`,`${header4Array.slice(2,4).join('、')} の認定件数まとめ`], '#F23B61', categories, false)
 
 const updateFuncAll = (chart: any) => {
   if(allChartInstance.value !== undefined) return ''

--- a/src/types/CarditisSummary.ts
+++ b/src/types/CarditisSummary.ts
@@ -4,7 +4,13 @@ export interface ICarditisSummaryRoot {
 	carditis_summary: ICarditisSummary
 	carditis_issues: {
 		date: string
-		issues_with_vaccine_name: ICarditisIssue[]
+		issues_with_vaccine_name: ICarditisIssueWithVaccineName[]
+		issues_by_manufacturers: ICarditisIssueWithManufacturer[]
+		issues_by_ages: {
+			ages_count: number
+			unknown_ages_count: number
+			issues: {x:string, y:number}[]
+		}
 	}
 }
 
@@ -16,8 +22,14 @@ export interface ICarditisSummary {
 	source: ISourceInfo
 }
 
-export interface ICarditisIssue {
+export interface ICarditisIssueWithVaccineName {
 	vaccine_name: string
+	myocarditis_count: number
+	pericarditis_count: number
+}
+
+export interface ICarditisIssueWithManufacturer {
+	manufacturer: string
 	myocarditis_count: number
 	pericarditis_count: number
 }

--- a/src/types/DeathSummary.ts
+++ b/src/types/DeathSummary.ts
@@ -10,6 +10,7 @@ export interface IDeathSummary {
 	source: ISourceInfo
 	sum_by_evaluation: ISumByEvaluation
 	sum_by_vaccine_name: ISumByVaccineName[]
+	sum_by_manufacturer: ISumByManufacturer[]
 }
 
 export interface ISumByEvaluation {
@@ -28,6 +29,11 @@ export interface IEvaluations {
 	alpha: number
 	beta: number
 	gamma: number
+}
+
+export interface ISumByManufacturer {
+	manufacturer: string
+	death_count: number
 }
 
 export interface IDeathIssues {

--- a/src/types/DeathSummaryFromReports.ts
+++ b/src/types/DeathSummaryFromReports.ts
@@ -6,6 +6,8 @@ export interface IDeathSummaryFromReportsRoot {
 
 export interface IDeathSummaryFromReports {
 	date: string
+	ages_count: number
+	unknown_ages_count: number
 	sum_by_age: I2DItem[]
 	lot_no_info: ILotNumberInformation
 }

--- a/src/views/SuspectedIssuesView.vue
+++ b/src/views/SuspectedIssuesView.vue
@@ -52,72 +52,26 @@
         </v-col>
       </v-row>
 
-      <CustomHeader2 title="心筋炎の件数内訳"></CustomHeader2>
-      <div class="d-flex justify-end">
-        <v-btn size="small" @click="changeChartView" color="blue" v-if="isPersentView">件数を表示</v-btn>
-        <v-btn size="small" @click="changeChartView" color="blue" v-else>割合を表示</v-btn>
+      <CustomHeader2 title="製造販売業者別の集計"></CustomHeader2>
+      <div class="text-body-1">
+        心筋炎の報告 {{ carditisSummaryData.carditis_summary.myocarditis.toLocaleString() }} 件 を製造販売業者ごとに集計した結果です。
       </div>
-      <v-row class="mb-2">
-        <v-col cols="12" md="8">
-          <apexchart :options="myocarditisByVaccineOptions" :series="myocarditisByVaccineSeries"></apexchart>
-        </v-col>
+      <HorizontalBarGraph :graph-title="['心筋炎の報告件数（製造販売業者別）']"
+          x-axis-title="報告件数" download-file-name="myocarditis-count-by-manufacturer" :series="myocarditisSeries"></HorizontalBarGraph>
 
-        <v-col  cols="12" md="4">
-          <v-table density="comfortable">
-            <thead>
-              <tr>
-                <th class="text-left">ワクチン名</th>
-                <th class="text-left">心筋炎件数</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="label, index in myocarditisByVaccineLabels" :key="label">
-                <td class="small-cell">{{ addNewLineWithBrackets(label) }}</td>
-                <td class="text-right">{{ myocarditisByVaccineSeries[index].toLocaleString() }}</td>
-              </tr>
-              <tr>
-                <td><b>合計</b></td>
-                <td class="text-right text-body-2"><b>{{ myocarditisByVaccineSeries.reduce(function(a, x){return a + x;}).toLocaleString() }}</b></td>
-              </tr>
-            </tbody>
-          </v-table>
-        </v-col>
-      </v-row>
-
-      <CustomHeader2 title="心膜炎の件数内訳"></CustomHeader2>
-      <div class="d-flex justify-end">
-        <v-btn size="small" @click="changeChartView" color="blue" v-if="isPersentView">件数を表示</v-btn>
-        <v-btn size="small" @click="changeChartView" color="blue" v-else>割合を表示</v-btn>
+      <div class="text-body-1 mt-2">
+        心膜炎の報告 {{ carditisSummaryData.carditis_summary.pericarditis.toLocaleString() }} 件 を製造販売業者ごとに集計した結果です。
       </div>
-      <v-row>
-        <v-col cols="12" md="8">
-          <apexchart :options="pericarditisByVaccineOptions" :series="pericarditisByVaccineSeries"></apexchart>
-        </v-col>
+      <HorizontalBarGraph :graph-title="['心膜炎の報告件数（製造販売業者別）']"
+          x-axis-title="報告件数" download-file-name="pericarditis-count-by-manufacturer" :series="pericarditisSeries"></HorizontalBarGraph>
 
-        <v-col  cols="12" md="4">
-          <v-table density="comfortable">
-            <thead>
-              <tr>
-                <th class="text-left">ワクチン名</th>
-                <th class="text-left">心膜炎件数</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="label, index in pericarditisByVaccineLabels" :key="label">
-                <td class="small-cell">{{ addNewLineWithBrackets(label) }}</td>
-                <td class="text-right">{{ pericarditisByVaccineSeries[index].toLocaleString() }}</td>
-              </tr>
-              <tr>
-                <td><b>合計</b></td>
-                <td class="text-right"><b>{{ pericarditisByVaccineSeries.reduce(function(a, x){return a + x;}).toLocaleString() }}</b></td>
-              </tr>
-            </tbody>
-          </v-table>
-        </v-col>
-      </v-row>
+      <CustomHeader2 title="年代別の集計"></CustomHeader2>
+      <div class="text-body-1 mb-5">
+        心筋炎/心膜炎の報告 {{ (carditisAgesCount + carditisUnknownAgesCount).toLocaleString() }} 件のうち、年代が判明している {{ carditisAgesCount.toLocaleString() }} 件を年代ごとに集計した結果です。（{{ carditisUnknownAgesCount.toLocaleString() }} 件は年代不明）
+      </div>
+      <CarditisPerAgeGraph :series="carditisSummaryByAges"></CarditisPerAgeGraph>
+      <p class="text-caption text-right mt-1">※ 「 <a :href="carditisSummaryData?.carditis_summary.source.url">{{ carditisSummaryData?.carditis_summary.source.name }}</a> 」が発表した資料の <b>{{ carditisSummaryData?.carditis_summary.date }}</b> 時点の数値を用いています。</p>
 
-      <p class="text-caption text-right mt-2">※ 「 <a :href="carditisSummaryData?.carditis_summary.source.url">{{ carditisSummaryData?.carditis_summary.source.name }}</a> 」で
-      発表された資料の <b>{{ carditisSummaryData?.carditis_summary.date }}</b> 時点の数値を用いています。</p>
     </v-container>
 
     <v-container v-if="deathSummaryData == undefined">
@@ -130,8 +84,8 @@
     </v-container>
 
     <v-container v-else>
-      <CustomHeader1 title="亡くなった方々に関する報告"></CustomHeader1>
-      <p class="text-body-1 mb-2">
+      <CustomHeader1 title="亡くなられた方々に関する報告"></CustomHeader1>
+      <p class="text-body-1 mb-3">
         「新型コロナワクチン接種後の死亡例」として製造販売業者から報告された事例 <span class="big-bold">{{ deathSummaryData?.death_summary.sum_by_evaluation.total.toLocaleString() }}</span> [件] の集計結果を示します。
       </p>
 
@@ -141,12 +95,12 @@
         <v-btn size="small" @click="changeChartView" color="blue" v-else>割合を表示</v-btn>
       </div>
 
-      <v-row>
+      <v-row class="mb-3">
         <v-col cols="12" sm="8">
           <apexchart :options="deathSummaryOptions" :series="deathSummarySeries"></apexchart>
         </v-col>
 
-        <v-col  cols="12" sm="4">
+        <v-col cols="12" sm="4">
           <v-table density="comfortable">
             <thead>
               <tr>
@@ -175,32 +129,15 @@
           </v-table>
           <EvaluationResultHelpDialog></EvaluationResultHelpDialog>
         </v-col>
-
-        <v-col cols="12" sm="8">
-          <apexchart :options="deathSummaryByVaccineOptions" :series="deathSummaryByVaccineSeries"></apexchart>
-        </v-col>
-
-        <v-col  cols="12" sm="4">
-          <v-table density="comfortable">
-            <thead>
-              <tr>
-                <th class="text-left">ワクチン名</th>
-                <th class="text-right">α・γの件数</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="label, index in deathSummaryByVaccineLabels" :key="label">
-                <td class="small-cell">{{ addNewLineWithBrackets(label) }}</td>
-                <td class="text-right">{{ deathSummaryByVaccineSeries[index].toLocaleString() }}</td>
-              </tr>
-              <tr>
-                <td><b>合計</b></td>
-                <td class="text-right"><b>{{ deathSummaryByVaccineSeries.reduce(function(a, x){return a + x;}).toLocaleString() }}</b></td>
-              </tr>
-            </tbody>
-          </v-table>
-        </v-col>
       </v-row>
+
+      <CustomHeader2 title="製造販売業者別の集計"></CustomHeader2>
+      <div class="text-body-1 mt-2">
+        専門家による因果関係評価がβとγの報告 <span class="big-bold">{{ (deathSummaryData?.death_summary.sum_by_evaluation.beta + deathSummaryData?.death_summary.sum_by_evaluation.gamma).toLocaleString() }}</span> [件] を製造販売業者ごとに集計した結果です。
+      </div>
+      <HorizontalBarGraph :graph-title="['死亡報告の件数（製造販売業者別）']"
+          x-axis-title="報告件数" download-file-name="death-count-by-manufacturer" :series="deathSummaryByManufacturer"></HorizontalBarGraph>
+      
     </v-container>
 
     <v-container v-if="deathSummaryDataFromReports == undefined">
@@ -213,8 +150,10 @@
     </v-container>
 
     <v-container v-else>
-      <CustomHeader2 title="年代別の内訳"></CustomHeader2>
-
+      <CustomHeader2 title="年代別の集計"></CustomHeader2>
+      <div class="text-body-1 mb-5">
+        亡くなられた方々に関する報告 {{ (deathAgesCount + deathUnknownAgesCount).toLocaleString() }} 件のうち、年代が判明している {{ deathAgesCount.toLocaleString() }} 件を年代ごとに集計した結果です。（{{ deathUnknownAgesCount.toLocaleString() }} 件は年代不明）
+      </div>
       <v-row>
         <v-col cols="12">
           <DeathPerAgeGraph :series="deathSummaryDataFromReports.death_summary_from_reports.sum_by_age"></DeathPerAgeGraph>
@@ -233,12 +172,14 @@ import { onMounted, shallowRef } from 'vue'
 import axios from 'axios'
 import { AppBarTitle, AppBarColor, CarditisSummaryURL, DeathSummaryURL, DeathSummaryFromReportsURL, AppBarUseHelpPage, AppBarHelpPageLink } from '@/router/data'
 import router from '@/router/index'
-import type { ICarditisSummaryRoot } from '@/types/CarditisSummary'
+import { type ICarditisSummaryRoot } from '@/types/CarditisSummary'
 import type { IDeathSummaryRoot } from '@/types/DeathSummary'
 import type { IDeathSummaryFromReportsRoot } from '@/types/DeathSummaryFromReports'
 import EvaluationResultHelpDialog from '@/components/EvaluationResultHelpDialog.vue'
 import CustomHeader1 from '@/components/CustomHeader1.vue'
 import CustomHeader2 from '@/components/CustomHeader2.vue'
+import HorizontalBarGraph from '@/components/HorizontalBarGraph.vue'
+import CarditisPerAgeGraph from '@/components/CarditisPerAgeGraph.vue'
 import DeathPerAgeGraph from '@/components/DeathPerAgeGraph.vue'
 
 AppBarTitle.value = String(router.currentRoute.value.name)
@@ -247,8 +188,16 @@ AppBarUseHelpPage.value = true
 AppBarHelpPageLink.value = 'how-to-use-summary-page'
 
 const carditisSummaryData = shallowRef<ICarditisSummaryRoot>()
+const myocarditisSeries = shallowRef<{x: string, y: number}[]>([])
+const pericarditisSeries = shallowRef<{x: string, y: number}[]>([])
+const carditisSummaryByAges = shallowRef<{x:string, y:number}[]>([])
+const carditisAgesCount = shallowRef<number>(0)
+const carditisUnknownAgesCount = shallowRef<number>(0)
 const deathSummaryData = shallowRef<IDeathSummaryRoot>()
+const deathSummaryByManufacturer = shallowRef<{x:string, y:number}[]>([])
 const deathSummaryDataFromReports = shallowRef<IDeathSummaryFromReportsRoot>()
+const deathAgesCount = shallowRef<number>(0)
+const deathUnknownAgesCount = shallowRef<number>(0)
 onMounted(() => {
   axios
     .get<ICarditisSummaryRoot>(CarditisSummaryURL)
@@ -258,15 +207,20 @@ onMounted(() => {
       carditisSummarySeries.value.push(carditisSummaryData.value.carditis_summary.myocarditis)
       carditisSummarySeries.value.push(carditisSummaryData.value.carditis_summary.pericarditis)
 
-      for (let index = 0; index < carditisSummaryData.value.carditis_issues.issues_with_vaccine_name.length; index++) {
-        const issue = carditisSummaryData.value.carditis_issues.issues_with_vaccine_name[index]
-
-        myocarditisByVaccineLabels.value.push(issue.vaccine_name)
-        myocarditisByVaccineSeries.value.push(issue.myocarditis_count)
-
-        pericarditisByVaccineLabels.value.push(issue.vaccine_name)
-        pericarditisByVaccineSeries.value.push(issue.pericarditis_count)
+      const issuesByM = carditisSummaryData.value.carditis_issues.issues_by_manufacturers
+      const mSeries: {x: string, y: number}[] = []
+      const pSeries: {x: string, y: number}[] = []
+      for (let index = 0; index < issuesByM.length; index++) {
+        const issue = issuesByM[index];
+        mSeries.push({x: issue.manufacturer, y: issue.myocarditis_count})
+        pSeries.push({x: issue.manufacturer, y: issue.pericarditis_count})
       }
+      myocarditisSeries.value = mSeries
+      pericarditisSeries.value = pSeries
+      
+      carditisAgesCount.value = carditisSummaryData.value.carditis_issues.issues_by_ages.ages_count
+      carditisUnknownAgesCount.value = carditisSummaryData.value.carditis_issues.issues_by_ages.unknown_ages_count
+      carditisSummaryByAges.value = carditisSummaryData.value.carditis_issues.issues_by_ages.issues
       
       // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
       window.dispatchEvent(new Event('resize'))
@@ -285,11 +239,13 @@ onMounted(() => {
       deathSummaryLabels.value.push('γ')
       deathSummarySeries.value.push(deathSummaryData.value.death_summary.sum_by_evaluation.gamma)
 
-      for (let index = 0; index < deathSummaryData.value.death_summary.sum_by_vaccine_name.length; index++) {
-        const element = deathSummaryData.value.death_summary.sum_by_vaccine_name[index];
-        deathSummaryByVaccineLabels.value.push(element.vaccine_name)
-        deathSummaryByVaccineSeries.value.push(element.evaluations.alpha + element.evaluations.gamma)
+      const sum_by_manufacturer = deathSummaryData.value.death_summary.sum_by_manufacturer
+      const seriesManufacturer: {x:string, y:number}[] = []
+      for (let index = 0; index < sum_by_manufacturer.length; index++) {
+        const element = sum_by_manufacturer[index];
+        seriesManufacturer.push({x: element.manufacturer, y: element.death_count})
       }
+      deathSummaryByManufacturer.value = seriesManufacturer
 
       // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
       window.dispatchEvent(new Event('resize'))
@@ -300,6 +256,8 @@ onMounted(() => {
     .get<IDeathSummaryFromReportsRoot>(DeathSummaryFromReportsURL)
     .then((response) => {
       deathSummaryDataFromReports.value = response.data
+      deathAgesCount.value = response.data.death_summary_from_reports.ages_count
+      deathUnknownAgesCount.value = response.data.death_summary_from_reports.unknown_ages_count
 
       // 2つ目以降のグラフが手動リフレッシュ無しにちゃんと表示されるようにするために必要な処理
       window.dispatchEvent(new Event('resize'))
@@ -357,116 +315,6 @@ const carditisSummaryOptions = {
   }
 }
 
-const myocarditisByVaccineLabels = shallowRef<string[]>([])
-const myocarditisByVaccineSeries = shallowRef<any[]>([])
-const myocarditisByVaccineOptions = {
-  title: {
-    text: 'ワクチン種類ごとの心筋炎件数',
-    align: 'center',
-    offsetX: 10,
-    offsetY: 10,
-  },
-  chart: { type: 'pie' },
-  legend: {
-    position: 'bottom',
-  },
-  labels: myocarditisByVaccineLabels.value,
-  plotOptions: {
-    pie: {
-      dataLabels: {
-        minAngleToShowLabel: 0.1
-      }, 
-    }
-  },
-  tooltip: {
-    y: {
-        formatter: (val: any) => {
-          return (val as number).toLocaleString() + ' 件'
-        },
-    },
-  },
-  responsive: [{
-    breakpoint: 800,
-    options: {
-      chart: {
-        width: 300
-      }
-    }
-  }],
-  dataLabels: {
-    formatter: function (val: any, { seriesIndex, dataPointIndex, w } :any ) {
-      if(isPersentView.value){
-        return val.toFixed(1) + ' %'
-      } else {
-        return w.config.series[seriesIndex].toLocaleString() + ' 件'
-      }
-    },
-    style: {
-      fontSize: '1.2rem',
-      colors: ['#212121'],
-    },
-    background: {
-      enabled: true,
-      foreColor: '#fff',
-    }
-  }
-}
-
-const pericarditisByVaccineLabels = shallowRef<string[]>([])
-const pericarditisByVaccineSeries = shallowRef<any[]>([])
-const pericarditisByVaccineOptions = {
-  title: {
-    text: 'ワクチン種類ごとの心膜炎件数',
-    align: 'center',
-    offsetX: 10,
-    offsetY: 10,
-  },
-  chart: { type: 'pie' },
-  legend: {
-    position: 'bottom',
-  },
-  labels: pericarditisByVaccineLabels.value,
-  plotOptions: {
-    pie: {
-      dataLabels: {
-        minAngleToShowLabel: 0.1
-      }, 
-    }
-  },
-  tooltip: {
-    y: {
-        formatter: (val: any) => {
-          return (val as number).toLocaleString() + ' 件'
-        },
-    },
-  },
-  responsive: [{
-    breakpoint: 800,
-    options: {
-      chart: {
-        width: 300
-      }
-    }
-  }],
-  dataLabels: {
-    formatter: function (val: any, { seriesIndex, dataPointIndex, w } :any ) {
-      if(isPersentView.value){
-        return val.toFixed(1) + ' %'
-      } else {
-        return w.config.series[seriesIndex].toLocaleString() + ' 件'
-      }
-    },
-    style: {
-      fontSize: '1.2rem',
-      colors: ['#212121'],
-    },
-    background: {
-      enabled: true,
-      foreColor: '#fff',
-    }
-  }
-}
-
 const deathSummaryLabels = shallowRef<string[]>([])
 const deathSummarySeries = shallowRef<any[]>([])
 const deathSummaryOptions = {
@@ -476,9 +324,11 @@ const deathSummaryOptions = {
     offsetX: 10,
     offsetY: 10,
   },
-  chart: { type: 'pie' },
+  chart: { 
+    type: 'pie',
+  },
   legend: {
-    position: 'bottom',
+    position: 'right',
   },
   labels: deathSummaryLabels.value,
   plotOptions: {
@@ -522,78 +372,9 @@ const deathSummaryOptions = {
   }
 }
 
-const deathSummaryByVaccineLabels = shallowRef<string[]>([])
-const deathSummaryByVaccineSeries = shallowRef<any[]>([])
-const deathSummaryByVaccineOptions = {
-  title: {
-    text: 'α・γ評価のワクチン別 内訳',
-    align: 'center',
-    offsetX: 10,
-    offsetY: 10,
-  },
-  chart: { type: 'pie' },
-  legend: {
-    position: 'bottom',
-  },
-  labels: deathSummaryByVaccineLabels.value,
-  plotOptions: {
-    pie: {
-      dataLabels: {
-        minAngleToShowLabel: 0.1
-      }, 
-    }
-  },
-  tooltip: {
-    y: {
-        formatter: (val: any) => {
-          return (val as number).toLocaleString() + ' 件'
-        },
-    },
-  },
-  responsive: [{
-    breakpoint: 800,
-    options: {
-      chart: {
-        width: 300
-      }
-    }
-  }],
-  dataLabels: {
-    formatter: function (val: any, { seriesIndex, dataPointIndex, w } :any ) {
-      if(isPersentView.value){
-        return val.toFixed(2) + ' %'
-      } else {
-        return w.config.series[seriesIndex].toLocaleString() + ' 件'
-      }
-    },
-    style: {
-      fontSize: '1.2rem',
-      colors: ['#212121'],
-    },
-    background: {
-      enabled: true,
-      foreColor: '#fff',
-    }
-  }
-}
-
 const changeChartView = () => {
   isPersentView.value = !isPersentView.value
   window.dispatchEvent(new Event('resize'))
-}
-
-const addNewLineWithBrackets = (label: string): string => {
-  label = label.replace('（','(')
-  label = label.replace('）',')')
-  
-  let split = label.split('(')
-  if(split.length < 2) return label
-
-  let joined = split[0] + '\r\n'
-  for (let index = 1; index < split.length; index++) {
-    joined += '(' + split[index];
-  }
-  return joined
 }
 </script>
 


### PR DESCRIPTION
ダッシュボードのIssue https://github.com/vaccinesosjapan/dashboard/issues/55 を解決するための実装を行ったので、検証ページに反映して関係者に相談する。

## 主な変更点について

①　心筋炎/心膜炎の報告に関して、ワクチン名ごとの集計ではなく製造販売業者ごとの集計に変更。

![image](https://github.com/user-attachments/assets/0c0fedc3-4a6f-45ba-a13c-5232fffc1373)

②　心筋炎/心膜炎の報告に関して、年代別の集計を追加。

![image](https://github.com/user-attachments/assets/d6f717df-d9cd-4c1d-98ba-2c90105280d8)

③　亡くなられた方々の報告に関しても同様に、ワクチン名ごとの集計ではなく製造販売業者ごとの集計に変更。

④　亡くなられた方々の報告に関して、年代別の集計に対して「年代が判明した◯◯件に対して集計した」という説明を追加

![image](https://github.com/user-attachments/assets/5e51e49e-9197-4064-954a-216a60a441c6)
