### PR TITLE
feat: 指定した日付の審議結果を確認できる機能を追加

### DIFF
--- a/src/components/CountAndRateGraph.vue
+++ b/src/components/CountAndRateGraph.vue
@@ -17,10 +17,13 @@
         </ul>
       </div>
     </v-col>
+
     <v-col cols="12">
       <p class="text-caption text-right">{{ noticeForImage }}</p>
     </v-col>
   </v-row>
+
+  <SelectDateToOpenIssues :dates="datesForSelection" />
 
   <v-row class="d-none d-md-flex mt-3">
     <v-col cols="12">
@@ -51,6 +54,7 @@
 <script setup lang="ts">
 import type { IJudgedData, IJudgedDataGraphInfo } from '@/types/JudgedData';
 import { shallowRef } from 'vue';
+import SelectDateToOpenIssues from '@/components/SelectDateToOpenIssues.vue'
 
 const props = defineProps<{
   data: IJudgedData[]
@@ -80,6 +84,9 @@ for (let index = 0; index < props.data.length; index++) {
 	numberOfRepudiationSum.push(element.RepudiationCountSum)
 	numberOfCertifiedRateSum.push(element.CertifiedRateSum)
 }
+
+// 日付選択用に、日付が新しい方から古い方へと並び替える
+const datesForSelection = xAxisLabels.value.sort((one, two) => (one > two ? -1 : 1))
 
 // Seriesデータを作成
 const eachCountAndRateSeries = shallowRef<ISeriesValue[]>([])

--- a/src/components/CountAndRateGraph.vue
+++ b/src/components/CountAndRateGraph.vue
@@ -49,6 +49,8 @@
       <p class="text-caption text-right">{{ noticeForImage }}</p>
     </v-col>
   </v-row>
+
+  <SelectDateToOpenIssues :dates="datesForSelection" />
 </template>
 
 <script setup lang="ts">

--- a/src/components/SelectDateToOpenIssues.vue
+++ b/src/components/SelectDateToOpenIssues.vue
@@ -1,0 +1,89 @@
+<template>
+	<v-row justify="center" class="d-none d-sm-flex mt-3">
+		<v-col cols="12" md="3" sm="4">
+			<v-select :items="dates" v-model="selectedDate" :label="label" hide-details="auto">
+				<template v-slot:prepend-item>
+					<v-text-field
+						v-model="searchText"
+						placeholder="選択肢を絞り込み"
+						@input="searchFunc"
+						@click:clear="clearSearchText"
+						clearable
+						hide-details
+						class="mx-1"
+					></v-text-field>
+				</template>
+			</v-select>
+		</v-col>
+		<v-col cols="12" md="4" sm="5">
+			<v-btn @click="openIssues">審議会データを確認する</v-btn>
+		</v-col>
+	</v-row>
+
+	<v-row justify="center" class="d-flex d-sm-none">
+		<v-col cols="12">
+			<v-select :items="dates" v-model="selectedDate" :label="label" hide-details="auto">
+				<template v-slot:prepend-item>
+					<v-text-field
+						v-model="searchText"
+						placeholder="選択肢を絞り込み"
+						@input="searchFunc"
+						@click:clear="clearSearchText"
+						clearable
+						hide-details
+						class="mx-1"
+					></v-text-field>
+				</template>
+			</v-select>
+			<v-btn @click="openIssues" class="mt-1">審議会データを確認する</v-btn>
+		</v-col>
+	</v-row>
+
+	<v-snackbar v-model="snackbarActivator" :timeout="timeout" color="warning">
+      データを表示したい審議会の日付を選択してください。
+    </v-snackbar>
+</template>
+
+<script setup lang="ts">
+import { onMounted, shallowRef } from 'vue';
+import router from '@/router/index'
+
+defineProps<{
+}>()
+
+const dates = defineModel<string[]>('dates')
+
+const selectedDate = shallowRef<string>('')
+const label = shallowRef<string>('日付選択')
+
+const openIssues = () =>{
+	if(selectedDate.value == ''){
+		snackbarActivator.value = true
+		return
+	}
+	router.push({ path: 'certified-issues', query: { jdf: selectedDate.value } })
+}
+
+const snackbarActivator = shallowRef<boolean>(false)
+const timeout = 2000
+
+const searchText = shallowRef<string>('')
+const datesCopy = shallowRef<string[]>([])
+const searchFunc = () => {
+	dates.value = datesCopy.value.filter((item) => {
+		return item.toLowerCase().indexOf(searchText.value.toLowerCase()) > -1;
+	});
+}
+const clearSearchText = () => {
+	dates.value = datesCopy.value
+}
+
+onMounted(() => {
+	if(dates.value != undefined){
+		datesCopy.value = [...dates.value]
+	}
+})
+</script>
+
+<style scoped>
+</style>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/33578a11-2793-4e50-ac2f-0214f78cccf4)

* 日付を選択肢一覧から選んでボタンを押せば、その日付の審議結果一覧のページを表示する
* 日付の選択肢は、文字列でフィルタリング可能